### PR TITLE
Adding waitForSelector and move cleanup to after hook

### DIFF
--- a/tests/utils/application-management.js
+++ b/tests/utils/application-management.js
@@ -162,8 +162,9 @@ export const configureApplicationSettings = async (page, config) => {
  * @param {import('@playwright/test').Page} page
  */
 export const publishApplicationToLive = async page => {
+    await page.waitForSelector('[data-testid="app-publish-live-btn"]', { timeout: 20000 });
     await page.getByTestId('app-publish-live-btn').click();
-    await page.waitForTimeout(5000);
+    await page.waitForTimeout(2000);
 
     // Set up response waiter BEFORE the action
     const publishResponsePromise = page.waitForResponse(resp => resp.url().includes('/applications')


### PR DESCRIPTION
- Add waitForSelector before click Publish Button
- Cleanup moved to After Hook. This will be improved with API cleanup instead  UI